### PR TITLE
Opening SourceTarget xml now uses ArcGIS Pro dialog box

### DIFF
--- a/Shared/Dockpane1.xaml
+++ b/Shared/Dockpane1.xaml
@@ -115,7 +115,7 @@
                     <Button DockPanel.Dock="Right" Margin="4,4,0,4" x:Name="SelectButton" VerticalAlignment="Center" Style="{StaticResource Button16}" Click="SelectButton_Click" ToolTip="Open a configuration file (.xml)">
                         <Image Source="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/AddContent16.png" />
                     </Button>
-                    <TextBox DockPanel.Dock="Left" x:Name="FileName" VerticalAlignment="Center" TextWrapping="NoWrap" Text="" TextChanged="FileName_TextChanged" />
+                    <TextBox DockPanel.Dock="Left" x:Name="FileName" VerticalAlignment="Center" IsEnabled="False" TextWrapping="NoWrap" Text="" TextChanged="FileName_TextChanged" />
                 </DockPanel>
                 <Button Grid.Row="2" Margin="0" x:Name="RevertButton" VerticalAlignment="Center" HorizontalAlignment="Left" Width="Auto" Content="Revert..." Style="{DynamicResource Esri_SimpleButton}" Visibility="Collapsed" ToolTip="Discard changes and re-open the original file" Click="RevertButton_Click"/>
             </Grid>
@@ -129,7 +129,7 @@
                     <Button DockPanel.Dock="Right" Margin="4,4,0,4" x:Name="SourceButton" Style="{StaticResource Button16}" VerticalAlignment="Center" Click="SourceButton_Click" ToolTip="Replace the Source">
                         <Image Source="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/AddContent16.png" />
                     </Button>
-                    <TextBox DockPanel.Dock="Left" Grid.Column="0" x:Name="SourceLayer" VerticalAlignment="Center" TextWrapping="NoWrap" IsReadOnly="True" Text="" TextChanged="SourceLayer_TextChanged" />
+                    <TextBox DockPanel.Dock="Left" IsEnabled="False" Grid.Column="0" x:Name="SourceLayer" VerticalAlignment="Center" TextWrapping="NoWrap" IsReadOnly="True" Text="" TextChanged="SourceLayer_TextChanged" />
                 </DockPanel>
             </Grid>
             <Grid x:Name="ReplaceStack" Grid.Row="2" IsEnabled="False" Visibility="Collapsed" Margin="0,16,0,0">
@@ -162,7 +162,7 @@
                     <Button DockPanel.Dock="Right" Margin="4,4,0,4" x:Name="TargetButton" Style="{StaticResource Button16}" VerticalAlignment="Center" Click="TargetButton_Click" ToolTip="Replace the Target">
                         <Image Source="pack://application:,,,/ArcGIS.Desktop.Resources;component/Images/AddContent16.png" />
                     </Button>
-                    <TextBox DockPanel.Dock="Left" x:Name="TargetLayer" VerticalAlignment="Center" TextWrapping="NoWrap" IsReadOnly="True" Text="" TextChanged="TargetLayer_TextChanged" />
+                    <TextBox DockPanel.Dock="Left" x:Name="TargetLayer" VerticalAlignment="Center" IsEnabled="False" TextWrapping="NoWrap" IsReadOnly="True" Text="" TextChanged="TargetLayer_TextChanged" />
                 </DockPanel>
             </Grid>
         </Grid>

--- a/Shared/Dockpane1.xaml.cs
+++ b/Shared/Dockpane1.xaml.cs
@@ -968,23 +968,41 @@ namespace DataAssistant
 
         private void SelectButton_Click(object sender, RoutedEventArgs e)
         {
-            using (var dlg = new System.Windows.Forms.OpenFileDialog())
+            string thePath = "";
+            var dlg = new ArcGIS.Desktop.Catalog.OpenItemDialog();
             {
-                dlg.Filter = "Data Loading Assistant Xml files|*.xml";//.Description = "Browse for a Source-Target File (.xml)";
-                dlg.Multiselect = false;
-                System.Windows.Forms.DialogResult result = dlg.ShowDialog();
-                if (result == System.Windows.Forms.DialogResult.OK)
+                dlg.Title = "Select Source-Configuration File";
+                dlg.MultiSelect = false;
+                bool? result = dlg.ShowDialog();
+                if (result == true)
                 {
-                    //this.FileName.Text = dlg.FileName;
-                    if (checkXmlFileName(dlg.FileName))
-                    {
-                        loadFile(dlg.FileName);
-                    }
+                    IEnumerable<Item> items = dlg.Items;
+                    foreach (Item selectedItem in items)
+                        thePath = selectedItem.Path;
                 }
             }
+                    if (checkXmlFileName(thePath))
+                    {
+                        loadFile(thePath);
+                    }
+            //Previous implementation is commented below in case of any stability issues
+
+            //using (var dlg = new System.Windows.Forms.OpenFileDialog())
+            //{
+            //    dlg.Filter = "Data Loading Assistant Xml files|*.xml";//.Description = "Browse for a Source-Target File (.xml)";
+            //    dlg.Multiselect = false;
+            //    System.Windows.Forms.DialogResult result = dlg.ShowDialog();
+            //    if (result == System.Windows.Forms.DialogResult.OK)
+            //    {
+            //        //this.FileName.Text = dlg.FileName;
+            //        if (checkXmlFileName(dlg.FileName))
+            //        {
+            //            loadFile(dlg.FileName);
+            //        }
+            //    }
+            //}
 
         }
-
         private void FileName_TextChanged(object sender, TextChangedEventArgs e)
         {
             TextBox txt = sender as TextBox;


### PR DESCRIPTION
Implementation of issue #193 
I also disabled the TextBoxes on the "File" tab because you were able to click into them. The only time that was at all useful was if you were to paste in the exact address (ending in the xml file) into the text box which didn't seem like a reasonable workflow. 